### PR TITLE
Design adjustments (header, footer + docs page) & images

### DIFF
--- a/Impressum/impressum.html
+++ b/Impressum/impressum.html
@@ -4,11 +4,10 @@
     <title>CCMP - Impressum</title>
     <link rel="stylesheet" href="../global/global.css">
     <link rel="stylesheet" href="impressum.css">
-    <script src="impressum.js"></script>
 </head>
 <body>
     <header id="header">
-        <h1 id="heading"><a href="../index.html">Management Portal</a></h1>
+        <h1 id="heading"><a class="heading-link" href="../index.html">Management Portal</a></h1>
         <nav id="navigation">
             <p class="nav-items"><a class="nav-items-link" href="../links/links.html">Nützliche Links</a></p>
             <p class="nav-items"><a class="nav-items-link" href="../docs/docs.html">Wichtige Dokumente</a></p>
@@ -22,5 +21,5 @@
         <p id="impr">Impressum</p>
     </footer>
     
-    <script src="script.js"></script>
+    <script src="impressum.js"></script>
 </body>

--- a/calendar/calendar.html
+++ b/calendar/calendar.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <header id="header">
-        <h1 id="heading"><a href="../index.html">Management Portal</a></h1>
+        <h1 id="heading"><a class="heading-link" href="../index.html">Management Portal</a></h1>
 
         <nav id="navigation">
             <p class="nav-items"><a class="nav-items-link" href="../links/links.html">Nützliche Links</a></p>
@@ -15,11 +15,11 @@
             <p class="nav-items"><a class="nav-items-link" id="opened" href="#">Kurskalender</a></p>
         </nav>
     </header>
+    <img class="background-image" src="../images/dhbw.jpg">
     <div id="content">
     </div>
-    <footer id="footer"><a href ="../Impressum/impressum.html">
+    <footer id="footer" onclick="location.href='../impressum/impressum.html'">
         <p id="impr">Impressum</p>
-    </a>
     </footer>
     
     <script src="calendar.js"></script>

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -6,6 +6,9 @@ table, th, td {
 tr:nth-child(even) {
     background-color: rgb(212, 211, 211);
 }
+tr:nth-child(odd) {
+    background-color: white;
+}
 table {
     border: none;
     border-collapse: collapse;
@@ -25,5 +28,10 @@ th {
 }
 tr:hover:not(:first-child) {
     cursor: pointer;
-    background-color: gray;
+    background-color: rgb(202, 156, 156);
+}
+#searchInput {
+    height: 30px;
+    width: 250px;
+    margin-bottom: 20px;
 }

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -8,13 +8,14 @@
 <body>
     <header id="header">
 
-        <h1 id="heading"> <a href="../index.html">Management Portal</a></h1>
+        <h1 id="heading"><a class="heading-link" href="../index.html">Management Portal</a></h1>
         <nav id="navigation">
             <p class="nav-items"><a class="nav-items-link" href="../links/links.html">Nützliche Links</a></p>
             <p class="nav-items"><a class="nav-items-link" id="opened" href="#">Wichtige Dokumente</a></p>
             <p class="nav-items"><a class="nav-items-link" href="../calendar/calendar.html">Kurskalender</a></p>
         </nav>
     </header>
+    <img class="background-image" src="../images/dhbw.jpg">
     <div id="content">
         <input type="text" id="searchInput" onkeyup="search()" placeholder="Suchbegriff">
         <table id="table">
@@ -26,23 +27,22 @@
                 <td>GitHub</td>
                 <td>https://github.com/Robin2800/central-campus-management-portal/branches</td>
             </tr>
-            <tr>
+            <tr onclick="window.open('#')">
                 <td>Test Docks</td>
                 <td>https://TestLink.com/test/link/</td>
             </tr>
-            <tr>
+            <tr onclick="window.open('#')">
                 <td>TextDocs</td>
                 <td>https://TestLink.com/test/link/</td>
             </tr>
-            <tr>
+            <tr onclick="window.open('#')">
                 <td>TestDogs</td>
                 <td>https://TestLink.com/test/link/</td>
             </tr>
         </table>
     </div>
-    <footer id="footer"><a href ="../Impressum/impressum.html">
+    <footer id="footer" onclick="location.href='../impressum/impressum.html'">
         <p id="impr">Impressum</p>
-    </a>
     </footer>
 
     <script src="docs.js"></script>

--- a/global/global.css
+++ b/global/global.css
@@ -13,6 +13,10 @@ body {
 #heading {
     margin-left: 5%;
 }
+.heading-link {
+    color: black;
+    text-decoration: none;
+}
 #navigation {
     background-color: rgb(212, 211, 211);
     border: 1px solid gray;
@@ -46,14 +50,15 @@ body {
     bottom: 0;
     left: 0;
     right: 0;
-    width: 100%;
-    height:5%;
     background-color: rgb(247, 247, 247);
     border: 1px solid black;
 }
+#footer:hover {
+    cursor: pointer;
+    background-color: lightgray;
+}
 #impr{
-    margin-left: 47%;
-    margin-top: 0.5%;
+    text-align: center;
 }
 
 @keyframes bildeinblenden{

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <header id="header">
-        <h1 id="heading"><a href="../index.html">Management Portal</a></h1>
+        <h1 id="heading"><a class="heading-link" href="./index.html">Management Portal</a></h1>
         <nav id="navigation">
             <p class="nav-items"><a class="nav-items-link" href="links/links.html">Nützliche Links</a></p>
             <p class="nav-items"><a class="nav-items-link" href="docs/docs.html">Wichtige Dokumente</a></p>
@@ -18,9 +18,8 @@
     <div id="content">
         <p id="welcome-message">Lorem ipsuuum doolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
     </div>
-    <footer id="footer"> <a href ="Impressum/impressum.html">
+    <footer id="footer" onclick="location.href='impressum/impressum.html'">
         <p id="impr">Impressum</p>
-    </a>    
     </footer>
     
     <script src="script.js"></script>

--- a/links/links.html
+++ b/links/links.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <header id="header">
-        <h1 id="heading"><a href="../index.html">Management Portal</a></h1>
+        <h1 id="heading"><a class="heading-link" href="../index.html">Management Portal</a></h1>
         <nav id="navigation">
             <p class="nav-items"><a class="nav-items-link" id="opened" href="#">Nützliche Links</a></p>
             <p class="nav-items"><a class="nav-items-link" href="../docs/docs.html">Wichtige Dokumente</a></p>
@@ -61,9 +61,8 @@
                 <p id="txt">Hier findest du den gesamten Vorlesungsplan der DHBW falls die eingebaute Funktion des Vorlesungsplan vorrübergehend nicht funktionieren sollte.</p>
             </div>
     </div>
-    <footer id="footer"><a href ="../Impressum/impressum.html">
+    <footer id="footer" onclick="location.href='../impressum/impressum.html'">
         <p id="impr">Impressum</p>
-    </a>
     </footer>
     
     <script src="links.js"></script>


### PR DESCRIPTION
Adjusted some of the design of the docs page. Changed header + footer links to display without text-decoration.
Added background-images to all of the pages.

<img width="1552" alt="Bildschirmfoto 2021-05-05 um 19 15 42" src="https://user-images.githubusercontent.com/47002424/117182195-596f3900-add6-11eb-887d-c3f6f15e26c0.png">
